### PR TITLE
Table of content functionality

### DIFF
--- a/assets/site/scss/_main.scss
+++ b/assets/site/scss/_main.scss
@@ -124,3 +124,7 @@
   text-align: center;
   margin: 0 auto;
 }
+
+.toc {
+  background-color: var(--font-color);
+}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,6 +4,13 @@
     <div class="date">
       <p>{{ .Date.Format "January 2, 2006" }}</p>
     </div> <!-- class date -->
+    {{ if .Params.toc }}
+    <aside>
+      <h4>Table of Contents</h4>
+      {{ .TableOfContents }}
+    </aside>
+    <hr class="toc">
+    {{ end }}
     {{ .Content }}
     <div class="closing">
       <div>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -2,7 +2,7 @@
   <div id="post" class="post">
     <h1>{{ .Title }}</h1>
     <div class="date">
-      <p>{{ .Date.Format "January 2, 2006" }}</p>
+      <p>&mdash; {{ .Date.Format "January 2, 2006" }}</p>
     </div> <!-- class date -->
     {{ if .Params.toc }}
     <aside>


### PR DESCRIPTION
Add TOC functionality. Now if any post requires a TOC we only need to add `toc: true` in the front matter of the post.