### PR TITLE
Disable taxonomy and term kinds

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -23,8 +23,13 @@ params:
       url: https://github.com/albertogg
       handle: albertogg
 
-# Taxonomies activation
+# Taxonomies activation default.
 taxonomies:
   tag: "tags"
   category: "categories"
   series: "series"
+
+# Disable some kinds that I'm not using.
+disableKinds:
+- taxonomy
+- term


### PR DESCRIPTION
Cleanup the sitemap.xml by removing taxonomy and term from the site. These kinds generated additional pages that I'm not using.